### PR TITLE
fix sbt kill alias

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -2,7 +2,7 @@ alias ls="ls -Ah -F -G"
 ## --group-directories-first --color=auto"
 
 alias scala="scala -Dfile.encoding=UTF-8 -deprecation"
-alias kill_sbt="ps ax | grep sbt | grep -v grep | cut -d' ' -f2 | xargs kill -9"
+kill_sbt() { "pkill -l "$@" sbt" }
 
 alias sbt="/Users/jonshea/projects/sbt-extras/sbt"
 


### PR DESCRIPTION
was looking at another config file and noticed this.  changed kill_sbt to use pkill instead of ps|grep.  This also allows you to use -9 or -15 or -3 or -f as required.
